### PR TITLE
WIP x-axis doesn't like empty lists.

### DIFF
--- a/geom-viz/src/core.org
+++ b/geom-viz/src/core.org
@@ -1295,8 +1295,8 @@ TBD
     [{:keys [major minor attribs label]} axis tick1-fn tick2-fn label-fn]
     (svg/group
      (merge {:stroke "#000"} attribs)
-     (map tick1-fn major)
-     (map tick2-fn minor)
+     (seq (map tick1-fn major))
+     (seq (map tick2-fn minor))
      (svg/group (merge {:stroke "none"} label) (map label-fn major))
      axis))
 


### PR DESCRIPTION
The generated sablono works when it returns nil, but not if it returns
an empty list for the minor ticks, but I'm still getting a broken svg
when using the function directly rather than the sablono it generates.

Investigating.