### PR TITLE
Fix vec2.reflect

### DIFF
--- a/geom-core/src/vector.org
+++ b/geom-core/src/vector.org
@@ -647,7 +647,7 @@
    [_ v]
    (let [^doubles b #?(:clj (double-array 2) :cljs (js/Float32Array. 2))]
      (vm/rewrite-v2-v buf v 0.0
-       (let [d (mm/madd x vx y vy 2)]
+       (let [d (* (+ (* x vx) (* y vy)) 2.0)]
          (aset b 0 (double (mm/msub vx d x)))
          (aset b 1 (double (mm/msub vy d y)))
          (Vec2. b nil _meta)))))


### PR DESCRIPTION
It seems that `mm/madd` cannot be used here, since it gives
```
user=> (macroexpand '(mm/madd x vx y vy 2))
(clojure.core/+ (clojure.core/+ (clojure.core/* x vx) (clojure.core/* y vy)) 2)
```

It adds the `2` instead of multiply
