### PR TITLE
Added hook for callback in case of failure to load Image/texture

### DIFF
--- a/src/gl/buffers.org
+++ b/src/gl/buffers.org
@@ -307,6 +307,8 @@
                    (gl/bind)
                    (gl/configure (merge {:flip false :image img} opts)))
                  (when-let [cb (get opts :callback)] (cb tex img))))
+         (when-let [ecb (:error-callback opts)]
+           (set! (.-onerror img) ecb))
          (set! (.-src img) (get opts :src))
          tex)))
 #+END_SRC


### PR DESCRIPTION
Hi,
We've found that we need to be able to hook up some function in case the texture fails to load. In our case it's an API which can return a application/json in case there is no image which kicks off functions hooked up to the onerror property of the image.

I'm not sure that this is the best solution, or even that it works since I haven't hooked up our application to my local version of geom which I should probably do. But it's an outline. How do you think it looks?

I'll try hooking up our project against my local version of geom tomorrow.

See: http://stackoverflow.com/a/9815854/501017