### PR TITLE
Added option to pass CORS setting to image.

### DIFF
--- a/src/gl/buffers.org
+++ b/src/gl/buffers.org
@@ -309,6 +309,8 @@
                  (when-let [cb (get opts :callback)] (cb tex img))))
          (when-let [ecb (:error-callback opts)]
            (set! (.-onerror img) ecb))
+         (when-let [cors (:cors opts)]
+           (set! (.-crossOrigin img) cors))
          (set! (.-src img) (get opts :src))
          tex)))
 #+END_SRC


### PR DESCRIPTION
In order to use an image as a WebGL texture from an origin (domain/server) other than that which delivers the web page the cors setting must be set on the image. This PR allows the library consumer to pass in what they want `.-crossOrigin` set to under the `:cors` key in the options map.

Documentation on the topic can be found at:
https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_settings_attributes
https://developer.mozilla.org/en-US/docs/Web/HTML/CORS_enabled_image
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Img#Attributes