### PR TITLE
[core] add arity 2 to tetrahedron's IFaceAccess and fix face format

### DIFF
--- a/src/types/tetrahedron.org
+++ b/src/types/tetrahedron.org
@@ -107,8 +107,9 @@
    [[a b] [b c] [c a] [a d] [b d] [c d]])
   g/IFaceAccess
   (faces
-   [{[a b c d] :points}]
-   [[a b c] [a d b] [b d c] [c d a]])
+   ([t _] (g/faces t))
+   ([{[a b c d] :points}]
+    [[[a b c]] [[a d b]] [[b d c]] [[c d a]]]))
   g/IGraph
   (vertex-neighbors
    [{[a b c d] :points} v]


### PR DESCRIPTION
Adds the missing arity to tetrahedron's IFaceAccess implementation, and also
fixes the format of faces being returned. Each face needed to be wrapped inside
an additional vector, since face format should be [vertices attribs].