### PR TITLE
Check axis spec :major / :minor instead of :visible when drawing grid.

### DIFF
--- a/src/thi/ng/geom/viz/core.cljc
+++ b/src/thi/ng/geom/viz/core.cljc
@@ -77,7 +77,7 @@
 ;; | `:range`       | vec of range bounds  | Y          | nil                                    | Lower & upper bound of projected coordinates                             |
 ;; | `:pos`         | number               | Y          | nil                                    | Draw position of the axis (ypos for X-axis, xpos for Y-axis)             |
 ;; | `:major`       | seq of domain values | N          | nil                                    | Seq of domain positions at which to draw labeled tick marks              |
-;; | `:minor`       | seq of domain values | N          | nil                                    | Seq of domain positions at which                                         |
+;; | `:minor`       | seq of domain values | N          | nil                                    | Seq of domain positions at which to draw minor tick marks                |
 ;; | `:major-size`  | number               | N          | 10                                     | Length of major tick marks                                               |
 ;; | `:minor-size`  | number               | N          | 5                                      | Length of minor tick marks                                               |
 ;; | `:label`       | function             | N          | =(default-svg-label (value-format 2))= | Function to format & emit tick labels                                    |
@@ -122,7 +122,9 @@
 ;; *** Axis grid definition (:grid)
 ;;
 ;; *Note:* If no `:grid` spec is given in the main spec, no background
-;; *grid will be displayed...
+;; *grid will be displayed. If the axis is not `:visible`, the grid
+;; *will still be displayed as long as either `:major` or `:minor`
+;; *ticks are defined in the axis spec.
 ;;
 ;; | *Key*      | *Value* | *Required* | *Default*       | *Description*                                            |
 ;; |------------+---------+------------+-----------------+----------------------------------------------------------|
@@ -782,9 +784,9 @@
         scale-y (:scale y-axis)]
     (svg/group
      (merge {:stroke "#ccc" :stroke-dasharray "1 1"} attribs)
-     (if minor-x
+     (if (or (:major x-axis) (:minor x-axis))
        (map #(let [x (scale-x %)] (svg/line (vec2 x y1) (vec2 x y2))) (select-ticks x-axis minor-x)))
-     (if minor-y
+     (if (or (:major y-axis) (:minor y-axis))
        (map #(let [y (scale-y %)] (svg/line (vec2 x1 y) (vec2 x2 y))) (select-ticks y-axis minor-y))))))
 
 (defn svg-plot2d-cartesian

--- a/src/thi/ng/geom/viz/core.cljc
+++ b/src/thi/ng/geom/viz/core.cljc
@@ -346,7 +346,7 @@
     '()
     (let [dr (- d2 d1)
           d1' (m/roundto d1 delta)]
-      (filter #(m/in-range? d1 d2 %) (range d1' (+ d2 delta) delta)))))
+      (filter #(m/in-range? d1 d2 (m/roundto % m/*eps*)) (range d1' (+ d2 delta) delta)))))
 
 (defn linear-axis
   [{:keys [domain range major minor] :as spec}]

--- a/src/thi/ng/geom/viz/core.cljc
+++ b/src/thi/ng/geom/viz/core.cljc
@@ -850,11 +850,11 @@
         great?  (> (m/abs-diff x1 x2) m/PI)]
     (svg/group
      (merge {:stroke "#ccc" :stroke-dasharray "1 1"} attribs)
-     (if minor-x
+     (if (or (:major x-axis) (:minor x-axis))
        (map
         #(let [x (scale-x %)] (svg/line (project [x y1]) (project [x y2])))
         (select-ticks x-axis minor-x)))
-     (if minor-y
+     (if (or (:major y-axis) (:minor y-axis))
        (map
         #(let [y (scale-y %)]
            (if circle

--- a/src/thi/ng/geom/viz/core.cljc
+++ b/src/thi/ng/geom/viz/core.cljc
@@ -782,9 +782,9 @@
         scale-y (:scale y-axis)]
     (svg/group
      (merge {:stroke "#ccc" :stroke-dasharray "1 1"} attribs)
-     (if (:visible x-axis)
+     (if minor-x
        (map #(let [x (scale-x %)] (svg/line (vec2 x y1) (vec2 x y2))) (select-ticks x-axis minor-x)))
-     (if (:visible y-axis)
+     (if minor-y
        (map #(let [y (scale-y %)] (svg/line (vec2 x1 y) (vec2 x2 y))) (select-ticks y-axis minor-y))))))
 
 (defn svg-plot2d-cartesian
@@ -848,11 +848,11 @@
         great?  (> (m/abs-diff x1 x2) m/PI)]
     (svg/group
      (merge {:stroke "#ccc" :stroke-dasharray "1 1"} attribs)
-     (if (:visible x-axis)
+     (if minor-x
        (map
         #(let [x (scale-x %)] (svg/line (project [x y1]) (project [x y2])))
         (select-ticks x-axis minor-x)))
-     (if (:visible y-axis)
+     (if minor-y
        (map
         #(let [y (scale-y %)]
            (if circle


### PR DESCRIPTION
Currently when the viz-spec has :visible set to false, the grid is not drawn even though minor-x or minor-y is set to true.
