### PR TITLE
Check bounds when adding point to SpatialTree.

### DIFF
--- a/src/thi/ng/geom/spatialtree.cljc
+++ b/src/thi/ng/geom/spatialtree.cljc
@@ -150,7 +150,9 @@
         ^:mutable bounds])
 
   g/ISpatialTree
-  (add-point [_ p d] (add-point* _ p d) _)
+  (add-point [_ p d]
+    (when (g/contains-point? (g/bounds _) p)
+      (add-point* _ p d) _))
   (delete-point [_ p] (delete-point* _ p))
   (get-point [_] point)
   (get-point-data [_] data)
@@ -228,7 +230,9 @@
         ^:mutable bounds])
 
   g/ISpatialTree
-  (add-point [_ p d] (add-point* _ p d) _)
+  (add-point [_ p d]
+    (when (g/contains-point? (g/bounds _) p)
+      (add-point* _ p d) _))
   (delete-point [_ p] (delete-point* _ p))
   (get-point [_] point)
   (get-point-data [_] data)


### PR DESCRIPTION
Fixes https://github.com/thi-ng/geom/issues/75 .