### PR TITLE
Add deps.edn for easier library consumption.

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,16 @@
+{:paths ["src"]
+
+ :deps {org.clojure/clojure {:mvn/version "1.9.0"}
+        org.clojure/clojurescript {:mvn/version "1.10.238"}
+        thi.ng/color {:mvn/version "1.3.0"}
+        thi.ng/dstruct {:mvn/version "0.2.1"}
+        thi.ng/math {:mvn/version "0.2.1"}
+        thi.ng/ndarray {:mvn/version "0.3.2"}
+        thi.ng/shadergraph {:mvn/version "0.3.0"}
+        thi.ng/strf {:mvn/version "0.2.2"}
+        thi.ng/typedarrays {:mvn/version "0.1.6"}
+        thi.ng/xerror {:mvn/version "0.1.0"}
+        org.jogamp.gluegen/gluegen-rt {:mvn/version "2.3.2"}
+        org.jogamp.jogl/jogl-all {:mvn/version "2.3.2"}
+        cljs-log {:mvn/version "0.2.2"}
+        hiccup {:mvn/version "1.0.5"}}}


### PR DESCRIPTION
As an alternative to using the library from Maven, adding a `deps.edn` will enable one to use the latest version of the library[ directly from github](https://clojure.org/guides/deps_and_cli#_using_git_libraries).