### PR TITLE
Add support for SVG path segment formats, document the path function

### DIFF
--- a/src/thi/ng/geom/svg/core.cljc
+++ b/src/thi/ng/geom/svg/core.cljc
@@ -193,6 +193,31 @@
   (into [:g (svg-attribs attribs nil)] body))
 
 (defn path
+  "Represents an SVG path element.
+  `segments` is a sequence of path segments, in the format
+  [<command> & args]
+  that corresponds to the SVG path language, eg.
+
+  (path [[:M [0 0]] [:l [20 30]] [:Z]]
+        {:fill \"red\"})
+
+  For reference, the available commands are as follows.
+  Each has an uppercase (absolute coordinates)
+  and lowercase (relative coordinates) variant.
+
+  | Command | Name                     | Arguments                                             |
+  |---------+--------------------------+-------------------------------------------------------|
+  | M/m     | moveto                   | [pt]                                                  |
+  | L/l     | lineto                   | [pt]                                                  |
+  | H/h     | horizontal lineto        | [x]                                                   |
+  | V/v     | vertical lineto          | [y]                                                   |
+  | C/c     | cubic curveto            | [pt1 pt2 endpt]                                       |
+  | S/s     | smooth cubic curveto     | [pt2 endpt]                                           |
+  | Q/q     | quadratic curveto        | [pt1 endpt]                                           |
+  | T/t     | smooth quadratic curveto | [endpt]                                               |
+  | A/a     | elliptical arc           | [rx ry x-axis-rotation large-arc-flag sweep-flag x y] |
+  | Z/z     | closepath                | []                                                    |
+  "
   ([segments]
    (path segments nil))
   ([segments attribs]

--- a/src/thi/ng/geom/svg/core.cljc
+++ b/src/thi/ng/geom/svg/core.cljc
@@ -52,8 +52,6 @@
          (repeat n)
          (interpose " "))))
 
-;; TODO add missing path segment types (Q, T)
-
 (def path-segment-formats
   {:M ["M" *fmt-vec* " "]
    :m ["m" *fmt-vec* " "]
@@ -61,6 +59,12 @@
    :l ["l" *fmt-vec* " "]
    :C ["C" *fmt-vec* " " *fmt-vec* " " *fmt-vec* " "]
    :c ["c" *fmt-vec* " " *fmt-vec* " " *fmt-vec* " "]
+   :Q ["Q" *fmt-vec* " " *fmt-vec* " "]
+   :q ["q" *fmt-vec* " " *fmt-vec* " "]
+   :S ["S" *fmt-vec* " " *fmt-vec* " "]
+   :s ["s" *fmt-vec* " " *fmt-vec* " "]
+   :T ["T" *fmt-vec* " "]
+   :t ["t" *fmt-vec* " "]
    :A ["A" *fmt-vec* " " *ff* " " str " " str " " *fmt-vec* " "]
    :a ["a" *fmt-vec* " " *ff* " " str " " str " " *fmt-vec* " "]
    :Z ["Z"]


### PR DESCRIPTION
Like most other functions in this library, the `thi.ng.geom.svg.core/path` function was sadly undocumented, and it was particularly difficult to figure out what format the arguments were supposed to be in, so I took the liberty of adding a docstring. 