### PR TITLE
Physics particles are initialized with velocity equal to initial position vector

### DIFF
--- a/src/thi/ng/geom/physics/core.cljc
+++ b/src/thi/ng/geom/physics/core.cljc
@@ -275,7 +275,7 @@
   ([pos weight]
    (particle pos weight false))
   ([pos weight lock?]
-   (VerletParticle. pos (g/clear* pos) (g/clear* pos) lock? nil nil (/ 1.0 weight) nil)))
+   (VerletParticle. pos pos (g/clear* pos) lock? nil nil (/ 1.0 weight) nil)))
 
 (defn spring
   [a b rlen strength]


### PR DESCRIPTION
I was trying to start using the VerletPhysics routines, but ran into a problem where particles have an initial velocity.

I did some digging, and it looks like https://github.com/thi-ng/geom/commit/9e0bba891264f748208806f106f400d961d410ae changed the initial conditions for particles to always set `prev` to be `(vec2 0 0)`. Previously it set both current position and previous position to the initial position. The new behavior sets the initial velocity of a particle to `(- pos (vec2 0 0))`.

If the particles all start at 0,0 or very near this likely works out fine, but it seems like setting both pos and prev to the initial conditions would make more sense? Is there some other use case here I'm missing? Maybe the spring examples were in a coordinate system relative to origin?

Thank you for implementing all these geometry routines, it's been a really great & useful resource!