### PR TITLE
Extend Bezier and Line to support IFlip

### DIFF
--- a/src/thi/ng/geom/bezier.cljc
+++ b/src/thi/ng/geom/bezier.cljc
@@ -109,6 +109,9 @@
 ;; ** Type implementations
 
 (extend-type Bezier2
+  g/IFlip
+  (flip [_]
+    (Bezier2. (reverse (get _ :points))))
 
   g/IVertexAccess
   (vertices
@@ -156,6 +159,9 @@
     (gu/sample-uniform udist include-last? (g/vertices _))))
 
 (extend-type Bezier3
+  g/IFlip
+  (flip [_]
+    (Bezier3. (reverse (get _ :points))))
 
   g/IVertexAccess
   (vertices

--- a/src/thi/ng/geom/line.cljc
+++ b/src/thi/ng/geom/line.cljc
@@ -101,6 +101,10 @@
        (or mesh (bm/basic-mesh))
        (attr/generate-face-attribs [a b tb ta] 0 attribs opts))))
 
+  g/IFlip
+  (flip [_]
+    (Line2. (vec (rseq (get _ :points)))))
+
   g/IVertexAccess
   (vertices
     ([_] (get _ :points))
@@ -235,6 +239,10 @@
       (g/add-face
        (or mesh (bm/basic-mesh))
        (attr/generate-face-attribs [a b tb ta] 0 attribs opts))))
+
+  g/IFlip
+  (flip [_]
+    (Line3. (vec (rseq (get _ :points)))))
 
   g/IVertexAccess
   (vertices

--- a/test/thi/ng/geom/test/types/bezier.cljc
+++ b/test/thi/ng/geom/test/types/bezier.cljc
@@ -1,0 +1,28 @@
+(ns thi.ng.geom.test.types.bezier
+  #?(:cljs
+     (:require-macros
+      [cemerick.cljs.test :refer (is deftest)]))
+  (:require
+   [thi.ng.math.core :as m]
+   [thi.ng.geom.core :as g]
+   [thi.ng.geom.types]
+   [thi.ng.geom.bezier :as b]
+   [thi.ng.geom.vector :as v]
+   #?(:clj
+      [clojure.test :refer :all]
+      :cljs
+      [cemerick.cljs.test])))
+
+(deftest test-flip
+  (let [bezier (b/bezier2 [(v/vec2) (v/vec2 2 2) (v/vec2 4 0)])
+        flip-bezier (g/flip bezier)]
+    (is (m/delta= (g/point-at bezier 0.4) (v/vec2 1.6 1.6)))
+    (is (m/delta= (g/point-at flip-bezier 0.6) (v/vec2 1.6 1.6)))
+    (is (m/delta= (g/point-at bezier 0.5) (g/point-at flip-bezier 0.5)))
+    (is (m/delta= (g/point-at bezier 0.1) (g/point-at flip-bezier 0.9))))
+  (let [bezier (b/bezier3 [(v/vec3) (v/vec3 2 2 2) (v/vec3 4 0 0)])
+        flip-bezier (g/flip bezier)]
+    (is (m/delta= (g/point-at bezier 0.6) (v/vec3 2.4 1.6 1.6)))
+    (is (m/delta= (g/point-at flip-bezier 0.4) (v/vec3 2.4 1.6 1.6)))
+    (is (m/delta= (g/point-at bezier 0.5) (g/point-at flip-bezier 0.5)))
+    (is (m/delta= (g/point-at bezier 0.1) (g/point-at flip-bezier 0.9)))))

--- a/test/thi/ng/geom/test/types/line.cljc
+++ b/test/thi/ng/geom/test/types/line.cljc
@@ -1,0 +1,28 @@
+(ns thi.ng.geom.test.types.line
+  #?(:cljs
+     (:require-macros
+      [cemerick.cljs.test :refer (is deftest)]))
+  (:require
+   [thi.ng.math.core :as m]
+   [thi.ng.geom.core :as g]
+   [thi.ng.geom.types]
+   [thi.ng.geom.line :as l]
+   [thi.ng.geom.vector :as v]
+   #?(:clj
+      [clojure.test :refer :all]
+      :cljs
+      [cemerick.cljs.test])))
+
+(deftest test-flip
+  (let [line (l/line2 (v/vec2) (v/vec2 1 10))
+        flip-line (g/flip line)]
+    (is (m/delta= (g/point-at line 0.4) (v/vec2 0.4 4)))
+    (is (m/delta= (g/point-at flip-line 0.6) (v/vec2 0.4 4)))
+    (is (m/delta= (g/point-at line 0.5) (g/point-at flip-line 0.5)))
+    (is (m/delta= (g/point-at line 0.1) (g/point-at flip-line 0.9))))
+  (let [line (l/line3 (v/vec3) (v/vec3 1 10 1))
+        flip-line (g/flip line)]
+    (is (m/delta= (g/point-at line 0.4) (v/vec3 0.4 4 0.4)))
+    (is (m/delta= (g/point-at flip-line 0.6) (v/vec3 0.4 4 0.4)))
+    (is (m/delta= (g/point-at line 0.5) (g/point-at flip-line 0.5)))
+    (is (m/delta= (g/point-at line 0.1) (g/point-at flip-line 0.9)))))

--- a/test/thi/ng/geom/test/types/protocols.cljc
+++ b/test/thi/ng/geom/test/types/protocols.cljc
@@ -102,13 +102,13 @@
        {
         ;; 2d
         thi.ng.geom.types.Bezier2
-        (-> shape-common-2d (disj :poly :tess) (conj :isec :prox))
+        (-> shape-common-2d (disj :poly :tess) (conj :flip :isec :prox))
 
         thi.ng.geom.types.Circle2
         (conj shape-common-2d :isec :prox)
 
         thi.ng.geom.types.Line2
-        (-> shape-common-2d (disj :poly :mesh :tess) (conj :isec :prox))
+        (-> shape-common-2d (disj :poly :mesh :tess) (conj :flip :isec :prox))
 
         thi.ng.geom.types.Polygon2
         (conj shape-common-2d :chull :clip :flip :isec :prox)
@@ -122,7 +122,7 @@
         ;; 3d
 
         thi.ng.geom.types.Bezier3
-        (-> shape-common-3d (disj :poly :tess) (conj :isec :prox))
+        (-> shape-common-3d (disj :poly :tess) (conj :flip :isec :prox))
 
         thi.ng.geom.types.AABB
         (conj shape-common-3d :isec :prox :subdiv)
@@ -131,7 +131,7 @@
         (conj shape-common-3d :isec :prox :subdiv)
 
         thi.ng.geom.types.Line3
-        (-> shape-common-3d (disj :mesh :tess) (conj :isec :prox))
+        (-> shape-common-3d (disj :mesh :tess) (conj :flip :isec :prox))
 
         thi.ng.geom.types.Plane
         (-> shape-common-3d (disj :edge :tess :vert) (conj :flip :isec :prox))


### PR DESCRIPTION
Extends the Bezier2, Bezier3, Line2, and Line3 shapes to support IFlip. This can be a nice convenience function if iterating from 0 to 1 using `g/point-at`, allowing changes along the line to happen in reverse.

Adds basic test cases to verify behavior using `g/point-at` and `g/flip`.

Thanks again so much for creating such a useful library.