### PR TITLE
Implement uniform random point in polygon, triangle and circle

### DIFF
--- a/examples/svg/uniform_distribution.clj
+++ b/examples/svg/uniform_distribution.clj
@@ -1,0 +1,90 @@
+(ns thi.ng.geom.examples.svg.uniform-distribution
+  (:require [thi.ng.geom.circle :as c]
+            [thi.ng.geom.core :as g]
+            [thi.ng.geom.polygon :as p]
+            [thi.ng.geom.rect :as r]
+            [thi.ng.geom.svg.adapter :as adapt]
+            [thi.ng.geom.svg.core :as svg]
+            [thi.ng.geom.triangle :as t]
+            [thi.ng.geom.vector :as v]))
+
+(defn sample-points
+  ([shape sample-method]
+   (sample-points shape sample-method 400))
+  ([shape sample-method n]
+   (let [centered (g/center shape)]
+     (repeatedly n #(sample-method centered)))))
+
+(defn example [pos shape points description]
+  (let [shape-centered (g/center shape)]
+    (svg/group {}
+               (svg/text (g/translate pos (v/vec2 0 -70))
+                         description
+                         {:text-anchor "middle"})
+               (svg/group {:fill "none" :stroke "red"} (g/translate shape-centered pos))
+               (svg/group {:opacity 0.8}
+                          (for [[x y] points]
+                            (g/translate (c/circle x y 0.5) pos))))))
+
+(defn scene []
+  (let [circle (c/circle 0 0 50)
+        ;; ellipse is not implemented?
+        rectangle (r/rect 0 0 100 100)
+        rotated-rectangle (g/rotate rectangle 0.25)
+        triangle (t/triangle2 (v/vec2 0 0) (v/vec2 100 50) (v/vec2 25 100))
+        polygon (p/polygon2 [0 0] [50 75] [100 100] [100 50] [75 25])]
+    (svg/svg {:width 800 :height 600 :stroke "black"}
+             (example (v/vec2 100 100) circle
+                      (sample-points circle g/random-point-inside)
+                      "g/random-point-inside")
+             (example (v/vec2 300 100) circle
+                      (sample-points circle c/random-point-in-circle)
+                      "c/random-point-in-circle")
+             (example (v/vec2 500 100) circle
+                      (sample-points circle g/random-point 200)
+                      "g/random-point")
+             (example (v/vec2 700 100) circle
+                      (g/sample-uniform (g/center circle) 10 true)
+                      "g/sample-uniform")
+
+             (example (v/vec2 100 250) rectangle
+                      (sample-points rectangle g/random-point-inside)
+                      "g/random-point-inside")
+             (example (v/vec2 300 250) rotated-rectangle
+                      (sample-points rotated-rectangle g/random-point-inside)
+                      "g/random-point-inside (polygon)")
+             (example (v/vec2 500 250) rectangle
+                      (sample-points rectangle g/random-point 200)
+                      "g/random-point")
+             (example (v/vec2 700 250) rectangle
+                      (g/sample-uniform (g/center rectangle) 10 true)
+                      "g/sample-uniform")
+
+             (example (v/vec2 100 400) triangle
+                      (sample-points triangle g/random-point-inside)
+                      "g/random-point-inside")
+             (example (v/vec2 300 400) triangle
+                      (sample-points triangle t/random-point-in-triangle2)
+                      "t/random-point-in-triangle2")
+             (example (v/vec2 500 400) triangle
+                      (sample-points triangle g/random-point 200)
+                      "g/random-point")
+             (example (v/vec2 700 400) triangle
+                      (g/sample-uniform (g/center triangle) 10 true)
+                      "g/sample-uniform")
+
+             (example (v/vec2 300 550) polygon
+                      (sample-points polygon g/random-point-inside)
+                      "g/random-point-inside")
+             (example (v/vec2 500 550) polygon
+                      (sample-points polygon g/random-point 200)
+                      "g/random-point")
+             (example (v/vec2 700 550) polygon
+                      (g/sample-uniform (g/center polygon) 10 true)
+                      "g/sample-uniform")
+             )))
+
+(->> (scene)
+     adapt/all-as-svg
+     svg/serialize
+     (spit "out/uniform-distribution.svg"))

--- a/src/thi/ng/geom/circle.cljc
+++ b/src/thi/ng/geom/circle.cljc
@@ -24,6 +24,15 @@
   (let [m (m/mix p q)]
     (isec/intersect-circle-circle? _ (circle m (g/dist m p)))))
 
+;; https://stats.stackexchange.com/questions/481543/generating-random-points-uniformly-on-a-disk
+(defn random-point-in-circle
+  "Randomly generate a point inside of circle with uniform distribution."
+  [{p :p r :r}]
+  (-> (vec2 (* r (Math/sqrt (m/random)))
+            (* m/TWO_PI (m/random)))
+      g/as-cartesian
+      (m/+ p)))
+
 ;; Even though a circle is a specialization of an ellipse, we define
 ;; an extra type for performance reasons.
 

--- a/src/thi/ng/geom/polygon.cljc
+++ b/src/thi/ng/geom/polygon.cljc
@@ -3,6 +3,7 @@
    [thi.ng.geom.core :as g]
    [thi.ng.geom.utils :as gu]
    [thi.ng.geom.utils.intersect :as isec]
+   [thi.ng.geom.utils.probability :as prob]
    [thi.ng.geom.vector :as v :refer [vec2 vec3]]
    [thi.ng.geom.line :as l]
    [thi.ng.geom.triangle :as t]
@@ -364,7 +365,19 @@
     [{points :points} t] (gu/point-at t (conj points (first points))))
   (random-point
     [_] (g/point-at _ (m/random)))
-  (random-point-inside [_] nil) ; TODO
+  ;; Uniformly sample point from tessellated triangles of polygon
+  ;; https://blogs.sas.com/content/iml/2020/10/21/random-points-in-polygon.html
+  ;; https://observablehq.com/@scarysize/finding-random-points-in-a-polygon
+  (random-point-inside
+    [_]
+    "Uniformly sample point from inside polygon
+
+    Tessellates into triangles, randomly selects a triangle weighted by area,
+    and then samples a point inside of that triangle uniformly."
+    (->> (g/tessellate _)
+         (map t/triangle2)
+         (prob/rand-weighted-by g/area)
+         t/random-point-in-triangle2))
   (sample-uniform
     [{points :points} udist include-last?]
     (gu/sample-uniform udist include-last? (conj points (first points))))

--- a/src/thi/ng/geom/triangle.cljc
+++ b/src/thi/ng/geom/triangle.cljc
@@ -171,7 +171,8 @@
   "Randomly generate a point inside a 2d triangle with uniform distribution."
   [_]
   (let [points (get _ :points)
-        [s t] (sort [(rand) (rand)])
+        [a b] [(m/random) (m/random)]
+        [s t] (if (<= a b) [a b] [b a])
         weighting [s (- t s) (- 1 t)]]
     (apply m/+ (map m/* points weighting))))
 

--- a/src/thi/ng/geom/triangle.cljc
+++ b/src/thi/ng/geom/triangle.cljc
@@ -170,11 +170,10 @@
 (defn random-point-in-triangle2
   "Randomly generate a point inside a 2d triangle with uniform distribution."
   [_]
-  (let [points (get _ :points)
-        [a b] [(m/random) (m/random)]
-        [s t] (if (<= a b) [a b] [b a])
+  (let [[a b] [(m/random) (m/random)]
+        [s t] (if (< a b) [a b] [b a])
         weighting [s (- t s) (- 1 t)]]
-    (apply m/+ (map m/* points weighting))))
+    (gu/from-barycentric (get _ :points) weighting)))
 
 (extend-type Triangle2
 

--- a/src/thi/ng/geom/triangle.cljc
+++ b/src/thi/ng/geom/triangle.cljc
@@ -164,6 +164,17 @@
    (let [[o r] (circumcircle-raw a b c)]
      (Circle2. o r))))
 
+;; Kraemer Method
+;; http://extremelearning.com.au/evenly-distributing-points-in-a-triangle/
+;; https://stackoverflow.com/questions/47410054/generate-random-locations-within-a-triangular-domain/47418580#47418580
+(defn random-point-in-triangle2
+  "Randomly generate a point inside a 2d triangle with uniform distribution."
+  [_]
+  (let [points (get _ :points)
+        [s t] (sort [(rand) (rand)])
+        weighting [s (- t s) (- 1 t)]]
+    (apply m/+ (map m/* points weighting))))
+
 (extend-type Triangle2
 
   g/IArea

--- a/src/thi/ng/geom/utils/probability.cljc
+++ b/src/thi/ng/geom/utils/probability.cljc
@@ -1,0 +1,35 @@
+(ns thi.ng.geom.utils.probability
+  (:require [thi.ng.math.core :as m]))
+
+;; TODO: move namespace to thi.ng.math.core?
+
+(defn- mapping
+  "Create a mapping of every value in collection to f(value)."
+  [f coll]
+  (reduce (fn [m x] (assoc m x (f x))) {} coll))
+
+(defn rand-weighted
+  "Given a mapping of values to weights, randomly choose a value biased by weight"
+  [weights]
+  (let [sample (m/random (apply + (vals weights)))]
+    (loop [cumulative 0.0
+           [[choice weight] & remaining] weights]
+      (when weight
+        (let [sum (+ cumulative weight)]
+          (if (< sample sum)
+            choice
+            (recur sum remaining)))))))
+
+(defn rand-weighted-by
+  "Given a sequence of values `xs`, weight each value by a function `f` and return
+  a weighted random selection."
+  [f xs]
+  (rand-weighted (mapping f xs)))
+
+(comment
+  (rand-weighted {})
+  (frequencies (repeatedly 1000 #(rand-weighted {:a 0.2 :b 0.8})))
+  (frequencies (repeatedly 1000 #(rand-weighted {:a 0.1 :b 0.7 :c 0.2})))
+  (frequencies (repeatedly 1000 #(rand-weighted {:a 2 :b 8 :c 32})))
+  (rand-weighted-by inc [])
+  (frequencies (repeatedly 1000 #(rand-weighted-by inc [0 2 5]))))


### PR DESCRIPTION
I've created a couple of sketches using the `g/random-point-inside` sampling method from `ISample`, and found it to be very useful, so thank you for providing that functionality.

Unfortunately I discovered some limitations. Firstly, the method was not implemented on polygons, or rectangles that had been rotated (which upscales to a polygon). In the process of addressing that, I discovered that the implementation for triangles is biased towards the centroid and not distributed uniformly throughout. Finally, I determined that the method for circle is also biased towards the centroid and not uniform.

The screenshot below is generated using the additional example script `examples/svg/uniform_distribution.clj` and helps demonstrate the bias visually. The clumping bias is quite visible on both the circle and triangle examples.

![Screenshot from 2021-04-11 20-23-14](https://user-images.githubusercontent.com/6784/114328961-cb1fd400-9b03-11eb-99f5-cdfe464960a1.png)

The first column shows distributions generated using the existing `g/random-point-inside` routines. The second column shows all the functionality using the uniform methods. Lastly the final two columns demonstrate both the `sample-uniform` and `g/random-point` on hull methods appear to be functioning uniformly.

The algorithm for polygons involves tessellating into triangles, and then sampling the triangles weighted by area. I suspect the math routines added for weighted probability distributions belong in `thi.ng.math.core`, but wanted to include them here in the interest of a single PR to merge. If this is accepted, I am happy to create the PR necessary to migrate it into the other project.

I think my preference would be to replace the `random-point-inside` implementations to use the uniform algorithms, however, that may break existing works generated using these methods. I have tried to think of an alternate name like `random-point-inside-uniform` to add to the interface, but have not been particularly happy with any names I have thought of. Adding a new interface seems like it would allow a common access method without dropping backwards compatibility but requires a good name. In the interest of sharing the results back with the community I elected to just add each as a helper method, but re-use the `random-point-inside` interface for polygons as no existing functionality can depend on it biasing in a particular way.

One last note, `random-point-inside-triangle2` has only been tested on 2d triangles but should work fine in 3d, as the bias weights should work on vec3's just as well as vec2's.

Hopefully this functionality is useful for others! Thanks again for this great project.