### PR TITLE
Ensure tessellation of polygon2 returns a collection of triangle2

### DIFF
--- a/src/thi/ng/geom/polygon.cljc
+++ b/src/thi/ng/geom/polygon.cljc
@@ -8,10 +8,10 @@
    [thi.ng.geom.triangle :as t]
    [thi.ng.geom.basicmesh :as bm]
    [thi.ng.geom.attribs :as attr]
-   #?(:clj [thi.ng.geom.types] :cljs [thi.ng.geom.types :refer [Circle2 Polygon2]])
+   #?(:clj [thi.ng.geom.types] :cljs [thi.ng.geom.types :refer [Circle2 Polygon2 Triangle2]])
    [thi.ng.dstruct.core :as d]
    [thi.ng.math.core :as m :refer [PI HALF_PI THREE_HALVES_PI *eps*]])
-  #?(:clj (:import [thi.ng.geom.types Circle2 Polygon2])))
+  #?(:clj (:import [thi.ng.geom.types Circle2 Polygon2 Triangle2])))
 
 (defn polygon2
   ([points] (Polygon2. (mapv vec2 points)))
@@ -371,7 +371,7 @@
 
   g/ITessellate
   (tessellate
-    [_] (tessellate* _))
+    [_] (map #(Triangle2. %) (tessellate* _)))
 
   g/IRotate
   (rotate

--- a/test/thi/ng/geom/test/types/polygon.cljc
+++ b/test/thi/ng/geom/test/types/polygon.cljc
@@ -4,13 +4,13 @@
       [cemerick.cljs.test :refer (is deftest)]))
   (:require
    [thi.ng.geom.core :as g]
-   [thi.ng.geom.vector :refer [vec2]]
-   [thi.ng.geom.types]
+   #?(:clj [thi.ng.geom.types] :cljs [thi.ng.geom.types :refer [Triangle2]])
    [thi.ng.geom.polygon :as p]
    #?(:clj
       [clojure.test :refer :all]
       :cljs
-      [cemerick.cljs.test])))
+      [cemerick.cljs.test]))
+  #?(:clj (:import [thi.ng.geom.types Triangle2])))
 
 (deftest test-flip
   (let [poly (p/polygon2 [[0 0] [1 0] [1 1] [0 1]])
@@ -18,3 +18,7 @@
     (is (= (-> poly g/as-mesh g/faces count)
            (-> flipped-poly g/as-mesh g/faces count))
         "flipped polygon tesselates to same number of faces")))
+
+(deftest tessellation
+  (let [poly (p/polygon2 [[0 0] [1 0] [1 1] [0 1]])]
+    (is (every? #(instance? Triangle2 %) (g/tessellate poly)))))


### PR DESCRIPTION
The return type of ITessellate tessellate for Circle, Triangle2, and Rect all
return a collection of Triangle2. However, calling tessellate on a polygon returned a
collection of point triplets. This patch ensures uniformity in the return type
for tessellating 2d shapes.