### PR TITLE
Add argument parsing for triangle/circumcircle to improve coverage

### DIFF
--- a/src/thi/ng/geom/triangle.cljc
+++ b/src/thi/ng/geom/triangle.cljc
@@ -159,7 +159,17 @@
         [o (g/dist o b)]))))
 
 (defn circumcircle
-  ([t] (circumcircle (get t :a) (get t :b) (get t :c)))
+  ([t]
+   (cond (instance? Triangle2 t)
+         (let [{[a b c] :points} t]
+           (circumcircle a b c))
+         (map? t)
+         (let [{:keys [a b c]} t]
+           (circumcircle a b c))
+         (sequential? t)
+         (let [[a b c] t]
+           (circumcircle a b c))
+         :else (err/illegal-arg! t)))
   ([a b c]
    (let [[o r] (circumcircle-raw a b c)]
      (Circle2. o r))))

--- a/test/thi/ng/geom/test/types/triangle.cljc
+++ b/test/thi/ng/geom/test/types/triangle.cljc
@@ -1,0 +1,23 @@
+(ns thi.ng.geom.test.types.triangle
+  #?(:cljs
+     (:require-macros
+      [cemerick.cljs.test :refer (is deftest)]))
+  (:require
+   [thi.ng.geom.types]
+   [thi.ng.geom.circle :as c]
+   [thi.ng.geom.triangle :as t]
+   [thi.ng.geom.vector :as v]
+   #?(:clj
+      [clojure.test :refer [is deftest]]
+      :cljs
+      [cemerick.cljs.test])))
+
+(deftest test-circumcircle
+  (let [a (v/vec2 0 0)
+        b (v/vec2 4 0)
+        c (v/vec2 0 2)
+        expected (c/circle (v/vec2 2.0 0.0) 2.0)]
+    (is (= expected (t/circumcircle a b c)))
+    (is (= expected (t/circumcircle (t/triangle2 a b c))))
+    (is (= expected (t/circumcircle {:a a :b b :c c})))
+    (is (= expected (t/circumcircle [a b c])))))


### PR DESCRIPTION
Handles receiving a triangle, a map with points a,b,c and a sequential tuple of
three elements.

Also adds tests to cover these cases.

This allows constructions like `(map t/circumcircle triangles)` to work as expected instead of throwing errors around missing keys a,b,c.

However on the API design front, I'm a little hesitant about the use of `instance?`. I wonder if `thi.ng.geom.core` needs a `ICircumcircle` protocol, and not just the protocol with a bounding circle? It's also not clear how to handle this if the argument is a Triangle3 at this time?