### PR TITLE
Removes warning about update-keys replacement in thi.ng.geom.gl.camera

### DIFF
--- a/src/thi/ng/geom/gl/camera.cljc
+++ b/src/thi/ng/geom/gl/camera.cljc
@@ -1,5 +1,5 @@
 (ns thi.ng.geom.gl.camera
-  (:refer-clojure :exclude [apply])
+  (:refer-clojure :exclude [apply update-keys])
   (:require
    [thi.ng.math.core :as m]
    [thi.ng.geom.vector :as v :refer [vec3]]


### PR DESCRIPTION
The warning is:
```
Compile Warning: update-keys already refers to: cljs.core/update-keys being replaced by: 
thi.ng.geom.gl.camera/update-keys  target/public/cljs-out/release/thi/ng/geom/gl/camera.cljc   
line:26  column:1
```

`update-keys` was added in the recent clojure & clojurescript release